### PR TITLE
Define Wrapper for Bindings

### DIFF
--- a/bindgen_simple/build.rs
+++ b/bindgen_simple/build.rs
@@ -9,7 +9,10 @@ fn main() {
     let header_path = libdir_path.join("mathlib.h");
 
     println!("cargo::rerun-if-changed={}", header_path.display());
-    println!("cargo::rerun-if-changed={}", libdir_path.join("mathlib.c").display());
+    println!(
+        "cargo::rerun-if-changed={}",
+        libdir_path.join("mathlib.c").display()
+    );
 
     cc::Build::new()
         .file(libdir_path.join("mathlib.c"))
@@ -17,8 +20,11 @@ fn main() {
         .compile("mathlib");
 
     println!("cargo::rustc-link-lib=mathlib");
-    println!("cargo::rustc-link-search=native={}", env::var("OUT_DIR").unwrap());
-    
+    println!(
+        "cargo::rustc-link-search=native={}",
+        env::var("OUT_DIR").unwrap()
+    );
+
     let bindings = bindgen::Builder::default()
         .header(header_path.to_str().unwrap())
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
@@ -26,5 +32,7 @@ fn main() {
         .expect("Unable to generate bindings");
 
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap()).join("bindings.rs");
-    bindings.write_to_file(out_path).expect("Couldn't write bindings!");
+    bindings
+        .write_to_file(out_path)
+        .expect("Couldn't write bindings!");
 }

--- a/bindgen_simple/src/lib.rs
+++ b/bindgen_simple/src/lib.rs
@@ -1,0 +1,19 @@
+pub mod mathlib_rust {
+    include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+
+    pub fn lib_add(a: i32, b: i32) -> i32 {
+        unsafe { add(a, b) }
+    }
+
+    pub fn lib_subtract(a: i32, b: i32) -> i32 {
+        unsafe { subtract(a, b) }
+    }
+
+    pub fn lib_multiply(a: i32, b: i32) -> i32 {
+        unsafe { multiply(a, b) }
+    }
+
+    pub fn lib_divide(a: i32, b: i32) -> f64 {
+        unsafe { divide(a, b) }
+    }
+}

--- a/bindgen_simple/src/main.rs
+++ b/bindgen_simple/src/main.rs
@@ -1,5 +1,0 @@
-include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
-
-fn main() {
-    println!("Hello, world!");
-}

--- a/bindgen_simple/tests/ffi_tests.rs
+++ b/bindgen_simple/tests/ffi_tests.rs
@@ -1,0 +1,39 @@
+#[cfg(test)]
+mod tests {
+    use bindgen_simple::mathlib_rust;
+
+    #[test]
+    fn test_add() {
+        let a = 3;
+        let b = 5;
+        assert_eq!(a + b, mathlib_rust::lib_add(a, b));
+    }
+
+    #[test]
+    fn test_subtract() {
+        let a = 3;
+        let b = 5;
+        assert_eq!(a - b, mathlib_rust::lib_subtract(a, b));
+    }
+
+    #[test]
+    fn test_multiply() {
+        let a = 3;
+        let b = 5;
+        assert_eq!(a * b, mathlib_rust::lib_multiply(a, b));
+    }
+
+    #[test]
+    fn test_divide() {
+        let a = 3;
+        let b = 5;
+        assert_eq!(a as f64 / b as f64, mathlib_rust::lib_divide(a, b));
+    }
+
+    #[test]
+    fn test_divide_by_zero() {
+        let a = 3;
+        let b = 0;
+        assert_eq!(0.0, mathlib_rust::lib_divide(a, b));
+    }
+}


### PR DESCRIPTION
This PR create a library crate wrapper around the generated bindings including basic tests for the wrapper and internal bindings.

- Changes src/main.rs -> src/lib.rs
- Adds mathlib_rust module for wrapping c interop bindings
- Adds tests module for wrapping
- Formatting change in build.rs from cargo fmt